### PR TITLE
Update targetSdk to 35 and increment app version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,14 +11,14 @@ plugins {
 
 android {
     namespace = "co.com.alameda181.unidadresidencialalameda181"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "co.com.alameda181.unidadresidencialalameda181"
         minSdk = 26
-        targetSdk = 34
-        versionCode = 1_0_20_014
-        versionName = "V1.0.20 build 014 Se incorpora tarea de mensajes enviados por el administrador"
+        targetSdk = 35
+        versionCode = 1_0_20_015
+        versionName = "V1.0.20 build 015 Target SDK 35"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
- Updated compileSdk and targetSdk to 35.
- Incremented versionCode to 1_0_20_015.
- Updated versionName to "V1.0.20 build 015 Target SDK 35".

This change addresses Google Play requirements for new app versions.

Important: Thorough testing is required after merging due to the inability to test in the current environment because of complex project dependencies. Pay close attention to UI rendering (edge-to-edge effects) and any behavior changes introduced in Android 15 (API 35).